### PR TITLE
logging fix in workerpool.go

### DIFF
--- a/workerpool.go
+++ b/workerpool.go
@@ -189,7 +189,7 @@ func (cnw *ConcreteNodeWorker) recovery(ctx CnvContext, caller string) {
 		fmt.Println("recovered:", r, caller)
 		debug.PrintStack()
 	} else {
-		fmt.Println("no recovery needed:", r, caller)
-
+		ctx.SendLog(3, fmt.Sprintf("Worker:[%s] no recovery needed for Executor:[%s] recovered:[%v] caller:[%s]",
+			cnw.Name, cnw.Executor.GetUniqueIdentifier(), r, caller), nil)
 	}
 }


### PR DESCRIPTION
too many concurrent writes in console, fixed that by sending logs to a channel with fixed buffer size